### PR TITLE
Fix nullability for the `Face` property of `IHalfEdge`

### DIFF
--- a/src/Ethereality.DoublyConnectedEdgeList/IHalfEdge.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/IHalfEdge.cs
@@ -16,6 +16,6 @@ namespace Ethereality.DoublyConnectedEdgeList
 
         public IHalfEdge<TEdge, TPoint> Previous { get; }
 
-        public IFace<TEdge, TPoint>? Face { get; }
+        public IFace<TEdge, TPoint> Face { get; }
     }
 }

--- a/src/Ethereality.DoublyConnectedEdgeList/Internal/HalfEdge.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/Internal/HalfEdge.cs
@@ -35,7 +35,8 @@ namespace Ethereality.DoublyConnectedEdgeList
         IHalfEdge<TEdge, TPoint> IHalfEdge<TEdge, TPoint>.Previous =>
             Previous ?? throw new InvalidOperationException("A half edge must have a previous segment.");
 
-        IFace<TEdge, TPoint>? IHalfEdge<TEdge, TPoint>.Face => Face;
+        IFace<TEdge, TPoint> IHalfEdge<TEdge, TPoint>.Face =>
+            Face ?? throw new InvalidOperationException("A half edge must have a face.");
 
         public override string ToString() =>
             !(Next is null) 


### PR DESCRIPTION
The face property in IHalfEdge was incorrectly marked as `Nullable` but is not nullable.

Made it non nullable.