### PR TITLE
Fix distinct issue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,294 @@
+root=true
+
+[*]
+trim_trailing_whitespace=true
+insert_final_newline=true
+
+# ReSharper properties
+resharper_align_linq_query=true
+resharper_align_multiline_argument=true
+resharper_align_multiline_calls_chain=true
+resharper_align_multiline_expression=true
+resharper_align_multiline_extends_list=true
+resharper_align_multiline_for_stmt=true
+resharper_align_multline_type_parameter_constrains=true
+resharper_align_multline_type_parameter_list=true
+resharper_align_tuple_components=true
+resharper_apply_auto_detected_rules=false
+resharper_blank_lines_around_single_line_auto_property=1
+resharper_blank_lines_around_single_line_local_method=1
+resharper_blank_lines_around_single_line_property=1
+resharper_blank_lines_before_single_line_comment=1
+resharper_blank_lines_between_using_groups=1
+resharper_braces_for_for=required
+resharper_braces_for_foreach=required
+resharper_braces_for_ifelse=required
+resharper_braces_for_while=required
+resharper_csharp_align_multiline_parameter=true
+resharper_csharp_align_multiple_declaration=true
+resharper_csharp_blank_lines_around_field=0
+resharper_csharp_blank_lines_around_single_line_invocable=1
+resharper_csharp_empty_block_style=together_same_line
+resharper_csharp_keep_blank_lines_in_code=1
+resharper_csharp_keep_blank_lines_in_declarations=1
+resharper_csharp_outdent_commas=true
+resharper_csharp_stick_comment=false
+resharper_csharp_wrap_after_declaration_lpar=true
+resharper_csharp_wrap_after_invocation_lpar=true
+resharper_csharp_wrap_arguments_style=chop_if_long
+resharper_csharp_wrap_before_binary_opsign=true
+resharper_csharp_wrap_before_first_type_parameter_constraint=true
+resharper_csharp_wrap_chained_method_calls=chop_if_long
+resharper_csharp_wrap_extends_list_style=chop_if_long
+resharper_csharp_wrap_parameters_style=chop_if_long
+resharper_indent_nested_foreach_stmt=true
+resharper_indent_nested_for_stmt=true
+resharper_indent_nested_while_stmt=true
+resharper_indent_preprocessor_region=no_indent
+resharper_keep_existing_declaration_parens_arrangement=false
+resharper_keep_existing_embedded_arrangement=false
+resharper_keep_existing_expr_member_arrangement=false
+resharper_keep_existing_invocation_parens_arrangement=false
+resharper_namespace_declaration_braces=end_of_line
+resharper_namespace_indentation=none
+resharper_outdent_binary_ops=true
+resharper_place_attribute_on_same_line=false
+resharper_place_constructor_initializer_on_same_line=false
+resharper_place_linq_into_on_new_line=false
+resharper_place_namespace_definitions_on_same_line=true
+resharper_place_simple_embedded_statement_on_same_line=false
+resharper_wrap_array_initializer_style=chop_if_long
+resharper_wrap_before_extends_colon=true
+resharper_wrap_before_linq_expression=true
+resharper_wrap_chained_binary_expressions=chop_if_long
+resharper_use_collection_count_property_highlighting=false
+
+# ReSharper inspection severities
+resharper_arrange_redundant_parentheses_highlighting=hint
+resharper_arrange_this_qualifier_highlighting=hint
+resharper_arrange_type_member_modifiers_highlighting=hint
+resharper_arrange_type_modifiers_highlighting=hint
+resharper_built_in_type_reference_style_for_member_access_highlighting=hint
+resharper_built_in_type_reference_style_highlighting=hint
+resharper_inconsistent_naming_highlighting=suggestion
+resharper_redundant_base_qualifier_highlighting=warning
+resharper_suggest_var_or_type_built_in_types_highlighting=hint
+resharper_suggest_var_or_type_elsewhere_highlighting=hint
+resharper_suggest_var_or_type_simple_types_highlighting=hint
+
+# Roslynator
+dotnet_diagnostic.RCS1080.severity = none
+
+# Shell scripts
+[*.sh]
+end_of_line=lf
+
+[*.{cmd,bat}]
+end_of_line=crlf
+
+[*.cs]
+max_line_length=120
+
+###############################
+# Naming Conventions          #
+###############################
+
+# Use PascalCase for constant fields
+dotnet_naming_style.pascal_case_style.capitalization=pascal_case
+dotnet_naming_style.camel_case_style.capitalization=camel_case
+
+# PascalCase with I prefix
+dotnet_naming_style.interface_style.capitalization=pascal_case
+dotnet_naming_style.interface_style.required_prefix=I
+
+# PascalCase with T prefix
+dotnet_naming_style.type_parameter_style.capitalization=pascal_case
+dotnet_naming_style.type_parameter_style.required_prefix=T
+
+# camelCase with _ prefix
+dotnet_naming_style.underscore_camel_case_style.capitalization=camel_case
+dotnet_naming_style.underscore_camel_case_style.required_prefix=_
+
+###############################
+# Rules                       #
+###############################
+
+# Interfaces
+dotnet_naming_rule.interface_naming.symbols=interface_symbol
+dotnet_naming_rule.interface_naming.style=interface_style
+dotnet_naming_rule.interface_naming.severity=suggestion
+dotnet_naming_symbols.interface_symbol.applicable_kinds=interface
+dotnet_naming_symbols.interface_symbol.applicable_accessibilities=*
+
+# Classes, Structs, Enums, Properties, Methods, Events, Namespaces
+dotnet_naming_rule.class_naming.symbols=class_symbol
+dotnet_naming_rule.class_naming.style=pascal_case_style
+dotnet_naming_rule.class_naming.severity=suggestion
+
+dotnet_naming_symbols.class_symbol.applicable_kinds=class, struct, enum, property, method, event, namespace
+dotnet_naming_symbols.class_symbol.applicable_accessibilities=*
+
+# Type Parameters
+dotnet_naming_rule.type_parameter_naming.symbols=type_parameter_symbol
+dotnet_naming_rule.type_parameter_naming.style=type_parameter_style
+dotnet_naming_rule.type_parameter_naming.severity=suggestion
+
+dotnet_naming_symbols.type_parameter_symbol.applicable_kinds=type_parameter
+dotnet_naming_symbols.type_parameter_symbol.applicable_accessibilities=*
+
+# Const fields
+dotnet_naming_rule.const_field_naming.symbols=const_field_symbol
+dotnet_naming_rule.const_field_naming.style=pascal_case_style
+dotnet_naming_rule.const_field_naming.severity=suggestion
+
+dotnet_naming_symbols.const_field_symbol.applicable_kinds=field
+dotnet_naming_symbols.const_field_symbol.applicable_accessibilities=*
+dotnet_naming_symbols.const_field_symbol.required_modifiers=const
+
+# Static readonly fields
+dotnet_naming_rule.static_readonly_field_naming.symbols=static_readonly_field_symbol
+dotnet_naming_rule.static_readonly_field_naming.style=pascal_case_style
+dotnet_naming_rule.static_readonly_field_naming.severity=suggestion
+
+dotnet_naming_symbols.static_readonly_field_symbol.applicable_kinds=field
+dotnet_naming_symbols.static_readonly_field_symbol.applicable_accessibilities=*
+dotnet_naming_symbols.static_readonly_field_symbol.required_modifiers=readonly,static
+
+# Public fields
+dotnet_naming_rule.public_field_naming.symbols=public_field_symbol
+dotnet_naming_rule.public_field_naming.style=pascal_case_style
+dotnet_naming_rule.public_field_naming.severity=suggestion
+
+dotnet_naming_symbols.public_field_symbol.applicable_kinds=field
+dotnet_naming_symbols.public_field_symbol.applicable_accessibilities=public, internal, protected
+
+# Other fields
+dotnet_naming_rule.other_field_naming.symbols=other_field_symbol
+dotnet_naming_rule.other_field_naming.style=underscore_camel_case_style
+dotnet_naming_rule.other_field_naming.severity=suggestion
+
+dotnet_naming_symbols.other_field_symbol.applicable_kinds=field
+dotnet_naming_symbols.other_field_symbol.applicable_accessibilities=*
+
+# Everything Else
+dotnet_naming_rule.everything_else_naming.symbols=everything_else
+dotnet_naming_rule.everything_else_naming.style=camel_case_style
+dotnet_naming_rule.everything_else_naming.severity=suggestion
+
+dotnet_naming_symbols.everything_else.applicable_kinds=*
+dotnet_naming_symbols.everything_else.applicable_accessibilities=*
+
+###############################
+# Code formatting             #
+###############################
+
+# "This." and "Me." qualifiers
+dotnet_style_qualification_for_field=false : warning
+dotnet_style_qualification_for_property=false : warning
+dotnet_style_qualification_for_method=false : warning
+dotnet_style_qualification_for_event=false : warning
+
+# Language keywords instead of framework type names for type references
+dotnet_style_predefined_type_for_locals_parameters_members=true : warning
+dotnet_style_predefined_type_for_member_access=true : warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers=always : warning
+csharp_preferred_modifier_order=public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async : warning
+dotnet_style_readonly_field=true : warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators=never_if_unnecessary : suggestion
+dotnet_style_parentheses_in_relational_binary_operators=never_if_unnecessary : suggestion
+dotnet_style_parentheses_in_other_binary_operators=never_if_unnecessary : suggestion
+dotnet_style_parentheses_in_other_operators=never_if_unnecessary : suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer=true : warning
+dotnet_style_collection_initializer=true : warning
+dotnet_style_explicit_tuple_names=true : warning
+dotnet_style_prefer_inferred_tuple_names=true : warning
+dotnet_style_prefer_inferred_anonymous_type_member_names=true : warning
+dotnet_style_prefer_auto_properties=true : warning
+dotnet_style_prefer_is_null_check_over_reference_equality_method=true : warning
+dotnet_style_prefer_conditional_expression_over_assignment=true
+dotnet_style_prefer_conditional_expression_over_return=true
+
+# Null-checking preferences
+dotnet_style_coalesce_expression=true : warning
+dotnet_style_null_propagation=true : warning
+
+# Organize usings
+dotnet_sort_system_directives_first=true
+dotnet_separate_import_directive_groups=true
+
+# Implicit and explicit types
+csharp_style_var_for_built_in_types=true : warning
+csharp_style_var_when_type_is_apparent=true : warning
+csharp_style_var_elsewhere=true : warning
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods=when_on_single_line : warning
+csharp_style_expression_bodied_constructors=when_on_single_line : warning
+csharp_style_expression_bodied_operators=when_on_single_line : warning
+csharp_style_expression_bodied_properties=when_on_single_line : warning
+csharp_style_expression_bodied_indexers=when_on_single_line : warning
+csharp_style_expression_bodied_accessors=when_on_single_line : warning
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check=true : warning
+csharp_style_pattern_matching_over_as_with_null_check=true : warning
+
+# Inlined variable declarations
+csharp_style_inlined_variable_declaration=true : warning
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression=true : warning
+csharp_style_deconstructed_variable_declaration=true : warning
+csharp_style_pattern_local_over_anonymous_function=true : warning
+
+# "Null" checking preferences
+csharp_style_throw_expression=true : warning
+csharp_style_conditional_delegate_call=true : warning
+
+# Code block preferences
+csharp_prefer_braces=true : warning
+
+# Newline options
+csharp_new_line_before_open_brace=all
+csharp_new_line_before_else=true
+csharp_new_line_before_catch=true
+csharp_new_line_before_finally=true
+csharp_new_line_before_members_in_object_initializers=true
+csharp_new_line_before_members_in_anonymous_types=true
+csharp_new_line_between_query_expression_clauses=true
+
+csharp_indent_case_contents=true
+csharp_indent_switch_labels=true
+csharp_indent_labels=flush_left
+
+csharp_space_after_cast=false
+csharp_space_after_keywords_in_control_flow_statements=true
+csharp_space_between_method_declaration_parameter_list_parentheses=false
+csharp_space_between_method_call_parameter_list_parentheses=false
+csharp_space_between_parentheses=false
+csharp_space_before_colon_in_inheritance_clause=true
+csharp_space_after_colon_in_inheritance_clause=true
+csharp_space_around_binary_operators=before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses=false
+csharp_space_between_method_call_name_and_opening_parenthesis=false
+csharp_space_between_method_call_empty_parameter_list_parentheses=false
+
+# Wrapping options
+csharp_preserve_single_line_statements=false
+csharp_preserve_single_line_blocks=true
+
+[*.{c,c++,cc,cp,cpp,cs,cu,cuh,cxx,h,hh,hpp,hxx,inc,inl,ino,ipp,js,jsx,master,mpp,skin,tpp,ts,tsx,vb}]
+indent_style=space
+indent_size=4
+tab_width=4
+
+[*.{appxmanifest,asax,ascx,aspx,axml,build,config,cshtml,csproj,css,dbml,discomap,dtd,htm,html,json,jsproj,lsproj,njsproj,nuspec,proj,props,proto,razor,resjson,resw,resx,StyleCop,targets,tasks,vbproj,xaml,xamlx,xml,xoml,xsd}]
+indent_style=space
+indent_size=2
+tab_width=2

--- a/src/Ethereality.DoublyConnectedEdgeList/Dcel.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/Dcel.cs
@@ -23,14 +23,32 @@ namespace Ethereality.DoublyConnectedEdgeList
                 faces?.ToList() ?? throw new ArgumentNullException(nameof(faces));
         }
 
-        public IVertex<TEdge, TPoint>? FindVertex(TPoint point) =>
-            Vertices.SingleOrDefault(vertex => vertex.OriginalPoint.Equals(point));
+        public IVertex<TEdge, TPoint>? FindVertex(TPoint point)
+        {
+            if (point is null)
+            {
+                throw new ArgumentNullException(nameof(point));
+            }
 
-        public IHalfEdge<TEdge, TPoint>? FindHalfEdge(TPoint pointA, TPoint pointB) =>
-            HalfEdges.SingleOrDefault(
+            return Vertices.SingleOrDefault(vertex => vertex.OriginalPoint.Equals(point));
+        }
+
+        public IHalfEdge<TEdge, TPoint>? FindHalfEdge(TPoint pointA, TPoint pointB)
+        {
+            if (pointA is null)
+            {
+                throw new ArgumentNullException(nameof(pointA));
+            }
+
+            if (pointB is null)
+            {
+                throw new ArgumentNullException(nameof(pointB));
+            }
+
+            return HalfEdges.SingleOrDefault(
                 halfEdge =>
-                    halfEdge.Origin.OriginalPoint.Equals(pointA) &&
-                    halfEdge.Next.Origin.OriginalPoint.Equals(pointB));
+                    halfEdge.Origin.OriginalPoint.Equals(pointA) && halfEdge.Next.Origin.OriginalPoint.Equals(pointB));
+        }
 
         public IReadOnlyList<IVertex<TEdge, TPoint>> Vertices { get; }
 

--- a/src/Ethereality.DoublyConnectedEdgeList/Dcel.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/Dcel.cs
@@ -23,13 +23,14 @@ namespace Ethereality.DoublyConnectedEdgeList
                 faces?.ToList() ?? throw new ArgumentNullException(nameof(faces));
         }
 
-        public IHalfEdge<TEdge, TPoint>? FindHalfEdge(TPoint pointA, TPoint pointB)
-        {
-            return HalfEdges.SingleOrDefault(
+        public IVertex<TEdge, TPoint>? FindVertex(TPoint point) =>
+            Vertices.SingleOrDefault(vertex => vertex.OriginalPoint.Equals(point));
+
+        public IHalfEdge<TEdge, TPoint>? FindHalfEdge(TPoint pointA, TPoint pointB) =>
+            HalfEdges.SingleOrDefault(
                 halfEdge =>
                     halfEdge.Origin.OriginalPoint.Equals(pointA) &&
                     halfEdge.Next.Origin.OriginalPoint.Equals(pointB));
-        }
 
         public IReadOnlyList<IVertex<TEdge, TPoint>> Vertices { get; }
 

--- a/src/Ethereality.DoublyConnectedEdgeList/DcelFactory.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/DcelFactory.cs
@@ -33,9 +33,9 @@ namespace Ethereality.DoublyConnectedEdgeList
 
         private static Dictionary<TPoint, Vertex<TEdge, TPoint>> CreateVertices(IReadOnlyList<TEdge> edges)
         {
-            var allPoints = edges.SelectMany(edge => new[] {edge.PointA, edge.PointB}).ToList();
             var result = new Dictionary<TPoint, Vertex<TEdge, TPoint>>();
-
+            var allPoints = edges.SelectMany(edge => new[] {edge.PointA, edge.PointB});
+            
             foreach (var point in allPoints)
             {
                 if (result.ContainsKey(point))

--- a/src/Ethereality.DoublyConnectedEdgeList/DcelFactory.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/DcelFactory.cs
@@ -38,12 +38,13 @@ namespace Ethereality.DoublyConnectedEdgeList
 
             foreach (var point in allPoints)
             {
-                var existingCloseByVertex = result.Values.SingleOrDefault(vertex => vertex.OriginalPoint.Equals(point));
-
-                if (!result.ContainsKey(point))
+                if (result.ContainsKey(point))
                 {
-                    result.Add(point, existingCloseByVertex ?? new Vertex<TEdge, TPoint>(point));
+                    continue;
                 }
+
+                var existingCloseByVertex = result.Values.SingleOrDefault(vertex => vertex.OriginalPoint.Equals(point));
+                result.Add(point, existingCloseByVertex ?? new Vertex<TEdge, TPoint>(point));
             }
 
             return result;

--- a/src/Ethereality.DoublyConnectedEdgeList/Ethereality.DoublyConnectedEdgeList.csproj
+++ b/src/Ethereality.DoublyConnectedEdgeList/Ethereality.DoublyConnectedEdgeList.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 
-		<LangVersion>8</LangVersion>
+		<LangVersion>9</LangVersion>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Ethereality.DoublyConnectedEdgeList/Internal/Face.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/Internal/Face.cs
@@ -7,10 +7,7 @@ namespace Ethereality.DoublyConnectedEdgeList
         where TEdge : IEdge<TPoint>
         where TPoint : IEquatable<TPoint>
     {
-        public Face()
-        {
-            HalfEdges = new List<HalfEdge<TEdge, TPoint>>();
-        }
+        public Face() => HalfEdges = new List<HalfEdge<TEdge, TPoint>>();
 
         public List<HalfEdge<TEdge, TPoint>> HalfEdges { get; }
 

--- a/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
+++ b/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
@@ -836,18 +836,28 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
 
             // Assert Vertices
             result.Vertices.Should().HaveCount(3);
-            result.Vertices.Select(v => v.OriginalPoint).Should().Contain(new[] { a, veryCloseToB, c });
 
-            var vertexA = result.Vertices.Single(v => v.OriginalPoint == a);
-            var vertexB = result.Vertices.Single(v => v.OriginalPoint == veryCloseToB);
-            var vertexC = result.Vertices.Single(v => v.OriginalPoint == c);
+            var vertexA = result.FindVertex(a);
+            var vertexB = result.FindVertex(b);
+            var vertexBPrime = result.FindVertex(veryCloseToB);
+            var vertexC = result.FindVertex(c);
+
+            vertexA.Should().NotBeNull();
+            vertexA!.OriginalPoint.Should().Be(a);
+
+            vertexBPrime.Should().NotBeNull();
+            vertexBPrime.Should().BeSameAs(vertexB);
+            vertexBPrime!.OriginalPoint.Should().Be(b);
+
+            vertexC.Should().NotBeNull();
+            vertexC!.OriginalPoint.Should().Be(c);
 
             // Assert HalfEdges
             result.HalfEdges.Should().HaveCount(4);
-            var halfEdgeAB = result.FindHalfEdge(a, veryCloseToB);
-            var halfEdgeBA = result.FindHalfEdge(veryCloseToB, a);
-            var halfEdgeBC = result.FindHalfEdge(veryCloseToB, c);
-            var halfEdgeCB = result.FindHalfEdge(c, veryCloseToB);
+            var halfEdgeAB = result.FindHalfEdge(a, b);
+            var halfEdgeBA = result.FindHalfEdge(b, a);
+            var halfEdgeBC = result.FindHalfEdge(b, c);
+            var halfEdgeCB = result.FindHalfEdge(c, b);
 
             result.HalfEdges.Should().Contain(new[] { halfEdgeAB, halfEdgeBC, halfEdgeCB, halfEdgeBA });
 

--- a/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
+++ b/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
@@ -817,5 +817,80 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
             face5.HalfEdges.Should()
                  .Contain(new[] {halfEdgeHG, halfEdgeGF, halfEdgeFH});
         }
+
+        [Fact]
+        public void Given_points_considered_equal_Should_return_same_vertices()
+        {
+            // Arrange
+            var a = new TestPoint(0, 0);
+            var b = new TestPoint(0, 1);
+            var veryCloseToB = new TestPoint(0 + 1e-11, 1 + 1e-11);
+            var c = new TestPoint(0, 2);
+
+            var segmentA = new TestSegment(a, b);
+            var segmentB = new TestSegment(veryCloseToB, c);
+
+            // Act
+            var dcelFactory = new DcelFactory<TestSegment, TestPoint>(new TestSegmentComparer());
+            var result = dcelFactory.FromShape(new[] { segmentA, segmentB });
+
+            // Assert Vertices
+            result.Vertices.Should().HaveCount(3);
+            result.Vertices.Select(v => v.OriginalPoint).Should().Contain(new[] { a, veryCloseToB, c });
+
+            var vertexA = result.Vertices.Single(v => v.OriginalPoint == a);
+            var vertexB = result.Vertices.Single(v => v.OriginalPoint == veryCloseToB);
+            var vertexC = result.Vertices.Single(v => v.OriginalPoint == c);
+
+            // Assert HalfEdges
+            result.HalfEdges.Should().HaveCount(4);
+            var halfEdgeAB = result.FindHalfEdge(a, veryCloseToB);
+            var halfEdgeBA = result.FindHalfEdge(veryCloseToB, a);
+            var halfEdgeBC = result.FindHalfEdge(veryCloseToB, c);
+            var halfEdgeCB = result.FindHalfEdge(c, veryCloseToB);
+
+            result.HalfEdges.Should().Contain(new[] { halfEdgeAB, halfEdgeBC, halfEdgeCB, halfEdgeBA });
+
+            halfEdgeAB.Origin.Should().Be(vertexA);
+            halfEdgeBA.Origin.Should().Be(vertexB);
+            halfEdgeBC.Origin.Should().Be(vertexB);
+            halfEdgeCB.Origin.Should().Be(vertexC);
+
+            // Assert Vertices
+            vertexA.HalfEdges.Should().ContainSingle().Which.Should().Be(halfEdgeAB);
+
+            vertexB.HalfEdges.Should().HaveCount(2);
+            vertexB.HalfEdges.Should().Contain(new[] { halfEdgeBA, halfEdgeBC });
+            vertexC.HalfEdges.Should().ContainSingle().Which.Should().Be(halfEdgeCB);
+
+            // Assert HalfEdges
+            halfEdgeAB.Next.Should().Be(halfEdgeBC);
+            halfEdgeAB.Twin.Should().Be(halfEdgeBA);
+            halfEdgeAB.Previous.Should().Be(halfEdgeBA);
+            halfEdgeAB.OriginalSegment.Should().Be(segmentA);
+
+            halfEdgeBC.Next.Should().Be(halfEdgeCB);
+            halfEdgeBC.Twin.Should().Be(halfEdgeCB);
+            halfEdgeBC.Previous.Should().Be(halfEdgeAB);
+            halfEdgeBC.OriginalSegment.Should().Be(segmentB);
+
+            halfEdgeCB.Next.Should().Be(halfEdgeBA);
+            halfEdgeCB.Twin.Should().Be(halfEdgeBC);
+            halfEdgeCB.Previous.Should().Be(halfEdgeBC);
+            halfEdgeCB.OriginalSegment.Should().Be(segmentB);
+
+            halfEdgeBA.Next.Should().Be(halfEdgeAB);
+            halfEdgeBA.Twin.Should().Be(halfEdgeAB);
+            halfEdgeBA.Previous.Should().Be(halfEdgeCB);
+            halfEdgeBA.OriginalSegment.Should().Be(segmentA);
+
+            // Assert Faces
+            var face = result.Faces.Should().ContainSingle().Subject;
+
+            face.HalfEdges.Should().HaveCount(4);
+            face.HalfEdges.Should().Contain(new[] { halfEdgeAB, halfEdgeBA, halfEdgeBC, halfEdgeCB });
+
+            face.HalfEdges.All(he => he.Face == face).Should().BeTrue();
+        }
     }
 }

--- a/tests/Ethereality.DoublyConnectedEdgeList.Tests/TestPoint.cs
+++ b/tests/Ethereality.DoublyConnectedEdgeList.Tests/TestPoint.cs
@@ -2,7 +2,7 @@
 
 namespace Ethereality.DoublyConnectedEdgeList.Tests
 {
-    internal class TestPoint : IEquatable<TestPoint>
+    internal sealed class TestPoint : IEquatable<TestPoint>
     {
         private const double ComparisonTolerance = 1e-10;
 

--- a/tests/Ethereality.DoublyConnectedEdgeList.Tests/TestPoint.cs
+++ b/tests/Ethereality.DoublyConnectedEdgeList.Tests/TestPoint.cs
@@ -4,6 +4,8 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
 {
     internal class TestPoint : IEquatable<TestPoint>
     {
+        private const double ComparisonTolerance = 1e-10;
+
         public TestPoint(double x, double y)
         {
             X = x;
@@ -11,20 +13,24 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
         }
 
         public double X { get; }
+
         public double Y { get; }
 
         public bool Equals(TestPoint other)
         {
-            return X == other.X && Y == other.Y;
+            if (other is null)
+            {
+                return false;
+            }
+
+            return Math.Abs(X - other.X) < ComparisonTolerance
+                && Math.Abs(Y - other.Y) < ComparisonTolerance;
         }
 
         public override int GetHashCode() => HashCode.Combine(X, Y);
 
         public override string ToString() => $"({X},{Y})";
 
-        public override bool Equals(object obj)
-        {
-            return Equals(obj as TestPoint);
-        }
+        public override bool Equals(object obj) => Equals(obj as TestPoint);
     }
 }


### PR DESCRIPTION
We have an issue if two points are considered equal by the equality comparer but don't have the same hashcode, the Distinct fails and doesn't correctly consider the points equal, which result in the two close points being regrouped. This is especially important when the user wants to consider points that are "close" within a certain tolerance.

To fix the issue, we have changed the algorithm to create the same vertex for points that the user would consider equal (using the `Equals` method.