### PR TITLE
Fix the query which gets the existing vertex

### DIFF
--- a/src/Ethereality.DoublyConnectedEdgeList/DcelFactory.cs
+++ b/src/Ethereality.DoublyConnectedEdgeList/DcelFactory.cs
@@ -43,7 +43,7 @@ namespace Ethereality.DoublyConnectedEdgeList
                     continue;
                 }
 
-                var existingCloseByVertex = result.Values.SingleOrDefault(vertex => vertex.OriginalPoint.Equals(point));
+                var existingCloseByVertex = result.Values.FirstOrDefault(vertex => vertex.OriginalPoint.Equals(point));
                 result.Add(point, existingCloseByVertex ?? new Vertex<TEdge, TPoint>(point));
             }
 


### PR DESCRIPTION
The result dictionary contains ultimately all the points, therefore for each point there may be many entries in the dictionary that have a key close to the point. However, the Value associated to these points should be the same vertex.

The query cannot be expected to return a single result, so `FirstOrDefault` is the correct way to go, because all the elements selected should have the same `Vertex`, hence the first is a good as any.