### PR TITLE
Fix the edge comparer in the unit tests

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 5.0.101
+          dotnet-version: 6.0
       - name: Restore
         run: dotnet restore
       - name: Build
@@ -69,9 +69,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 5.0.101
+          dotnet-version: 6.0
       - name: Create Release NuGet package
         run: |
           arrTag=(${GITHUB_REF//\// })

--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -28,19 +28,30 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0
+          dotnet-version: 6.0.x
+
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
       - name: Restore
         run: dotnet restore
       - name: Build
         run: dotnet build -c Release --no-restore
       - name: Test
         run: dotnet test -c Release --no-build
+
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.7
       - name: Pack
         if: matrix.os == 'ubuntu-latest'
-        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=$GITHUB_RUN_ID src/$PROJECT_NAME/$PROJECT_NAME.*proj
+        run: dotnet pack -v normal -c Release --no-restore --include-symbols --include-source -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Upload Artifact
         if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v2
@@ -72,14 +83,16 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 6.0
+      - name: Install GitVersion
+        uses: gittools/actions/gitversion/setup@v0.9.7
+        with:
+          versionSpec: '5.x'
+      - name: Determine Version
+        id: gitversion
+        uses: gittools/actions/gitversion/execute@v0.9.7
       - name: Create Release NuGet package
         run: |
-          arrTag=(${GITHUB_REF//\// })
-          VERSION="${arrTag[2]}"
-          echo Version: $VERSION
-          VERSION="${VERSION//v}"
-          echo Clean Version: $VERSION
-          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=$VERSION -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
+          dotnet pack -v normal -c Release --include-symbols --include-source -p:PackageVersion=${{ steps.gitversion.outputs.semVer }} -o nupkg src/$PROJECT_NAME/$PROJECT_NAME.*proj
       - name: Push to GitHub Feed
         run: |
           for f in ./nupkg/*.nupkg

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,0 +1,5 @@
+mode: ContinuousDeployment
+tag-prefix: ''
+branches:
+  master:
+    tag: beta

--- a/src/Ethereality.DoublyConnectedEdgeList/Ethereality.DoublyConnectedEdgeList.csproj
+++ b/src/Ethereality.DoublyConnectedEdgeList/Ethereality.DoublyConnectedEdgeList.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
 
-		<LangVersion>9.0</LangVersion>
+		<LangVersion>10.0</LangVersion>
 
 		<PublishRepositoryUrl>true</PublishRepositoryUrl>
 		<EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
+++ b/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
@@ -696,112 +696,112 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
             halfEdgeBA.Previous.Should().Be(halfEdgeCB);
             halfEdgeBA.OriginalSegment.Should().Be(segmentA);
 
-            halfEdgeBC.Next.Should().Be(halfEdgeCD);
+            halfEdgeBC.Next.Should().Be(halfEdgeCH);
             halfEdgeBC.Twin.Should().Be(halfEdgeCB);
             halfEdgeBC.Previous.Should().Be(halfEdgeAB);
             halfEdgeBC.OriginalSegment.Should().Be(segmentB);
 
             halfEdgeCB.Next.Should().Be(halfEdgeBA);
             halfEdgeCB.Twin.Should().Be(halfEdgeBC);
-            halfEdgeCB.Previous.Should().Be(halfEdgeHC);
+            halfEdgeCB.Previous.Should().Be(halfEdgeDC);
             halfEdgeCB.OriginalSegment.Should().Be(segmentB);
 
-            halfEdgeCD.Next.Should().Be(halfEdgeDE);
+            halfEdgeCD.Next.Should().Be(halfEdgeDH);
             halfEdgeCD.Twin.Should().Be(halfEdgeDC);
-            halfEdgeCD.Previous.Should().Be(halfEdgeBC);
+            halfEdgeCD.Previous.Should().Be(halfEdgeHC);
             halfEdgeCD.OriginalSegment.Should().Be(segmentC);
 
-            halfEdgeDC.Next.Should().Be(halfEdgeCH);
+            halfEdgeDC.Next.Should().Be(halfEdgeCB);
             halfEdgeDC.Twin.Should().Be(halfEdgeCD);
-            halfEdgeDC.Previous.Should().Be(halfEdgeHD);
+            halfEdgeDC.Previous.Should().Be(halfEdgeED);
             halfEdgeDC.OriginalSegment.Should().Be(segmentC);
 
             halfEdgeDE.Next.Should().Be(halfEdgeEF);
             halfEdgeDE.Twin.Should().Be(halfEdgeED);
-            halfEdgeDE.Previous.Should().Be(halfEdgeCD);
+            halfEdgeDE.Previous.Should().Be(halfEdgeFD);
             halfEdgeDE.OriginalSegment.Should().Be(segmentD);
 
-            halfEdgeED.Next.Should().Be(halfEdgeDF);
+            halfEdgeED.Next.Should().Be(halfEdgeDC);
             halfEdgeED.Twin.Should().Be(halfEdgeDE);
             halfEdgeED.Previous.Should().Be(halfEdgeFE);
             halfEdgeED.OriginalSegment.Should().Be(segmentD);
 
-            halfEdgeEF.Next.Should().Be(halfEdgeFG);
+            halfEdgeEF.Next.Should().Be(halfEdgeFD);
             halfEdgeEF.Twin.Should().Be(halfEdgeFE);
             halfEdgeEF.Previous.Should().Be(halfEdgeDE);
             halfEdgeEF.OriginalSegment.Should().Be(segmentE);
 
             halfEdgeFE.Next.Should().Be(halfEdgeED);
             halfEdgeFE.Twin.Should().Be(halfEdgeEF);
-            halfEdgeFE.Previous.Should().Be(halfEdgeDF);
+            halfEdgeFE.Previous.Should().Be(halfEdgeGF);
             halfEdgeFE.OriginalSegment.Should().Be(segmentE);
 
-            halfEdgeFG.Next.Should().Be(halfEdgeGA);
+            halfEdgeFG.Next.Should().Be(halfEdgeGH);
             halfEdgeFG.Twin.Should().Be(halfEdgeGF);
-            halfEdgeFG.Previous.Should().Be(halfEdgeEF);
+            halfEdgeFG.Previous.Should().Be(halfEdgeHF);
             halfEdgeFG.OriginalSegment.Should().Be(segmentF);
 
-            halfEdgeGF.Next.Should().Be(halfEdgeFH);
+            halfEdgeGF.Next.Should().Be(halfEdgeFE);
             halfEdgeGF.Twin.Should().Be(halfEdgeFG);
-            halfEdgeGF.Previous.Should().Be(halfEdgeHG);
+            halfEdgeGF.Previous.Should().Be(halfEdgeAG);
             halfEdgeGF.OriginalSegment.Should().Be(segmentF);
 
-            halfEdgeGH.Next.Should().Be(halfEdgeHC);
+            halfEdgeGH.Next.Should().Be(halfEdgeHF);
             halfEdgeGH.Twin.Should().Be(halfEdgeHG);
-            halfEdgeGH.Previous.Should().Be(halfEdgeAG);
+            halfEdgeGH.Previous.Should().Be(halfEdgeFG);
             halfEdgeGH.OriginalSegment.Should().Be(segmentG);
 
-            halfEdgeHG.Next.Should().Be(halfEdgeGF);
+            halfEdgeHG.Next.Should().Be(halfEdgeGA);
             halfEdgeHG.Twin.Should().Be(halfEdgeGH);
-            halfEdgeHG.Previous.Should().Be(halfEdgeFH);
+            halfEdgeHG.Previous.Should().Be(halfEdgeCH);
             halfEdgeHG.OriginalSegment.Should().Be(segmentG);
 
-            halfEdgeDH.Next.Should().Be(halfEdgeHF);
+            halfEdgeDH.Next.Should().Be(halfEdgeHC);
             halfEdgeDH.Twin.Should().Be(halfEdgeHD);
-            halfEdgeDH.Previous.Should().Be(halfEdgeFD);
+            halfEdgeDH.Previous.Should().Be(halfEdgeCD);
             halfEdgeDH.OriginalSegment.Should().Be(segmentH);
 
-            halfEdgeHD.Next.Should().Be(halfEdgeDC);
+            halfEdgeHD.Next.Should().Be(halfEdgeDF);
             halfEdgeHD.Twin.Should().Be(halfEdgeDH);
-            halfEdgeHD.Previous.Should().Be(halfEdgeCH);
+            halfEdgeHD.Previous.Should().Be(halfEdgeFH);
             halfEdgeHD.OriginalSegment.Should().Be(segmentH);
 
-            halfEdgeHC.Next.Should().Be(halfEdgeCB);
+            halfEdgeHC.Next.Should().Be(halfEdgeCD);
             halfEdgeHC.Twin.Should().Be(halfEdgeCH);
-            halfEdgeHC.Previous.Should().Be(halfEdgeGH);
+            halfEdgeHC.Previous.Should().Be(halfEdgeDH);
             halfEdgeHC.OriginalSegment.Should().Be(segmentI);
 
-            halfEdgeCH.Next.Should().Be(halfEdgeHD);
+            halfEdgeCH.Next.Should().Be(halfEdgeHG);
             halfEdgeCH.Twin.Should().Be(halfEdgeHC);
-            halfEdgeCH.Previous.Should().Be(halfEdgeDC);
+            halfEdgeCH.Previous.Should().Be(halfEdgeBC);
             halfEdgeCH.OriginalSegment.Should().Be(segmentI);
 
-            halfEdgeFD.Next.Should().Be(halfEdgeDH);
+            halfEdgeFD.Next.Should().Be(halfEdgeDE);
             halfEdgeFD.Twin.Should().Be(halfEdgeDF);
-            halfEdgeFD.Previous.Should().Be(halfEdgeHF);
+            halfEdgeFD.Previous.Should().Be(halfEdgeEF);
             halfEdgeFD.OriginalSegment.Should().Be(segmentJ);
 
-            halfEdgeDF.Next.Should().Be(halfEdgeFE);
+            halfEdgeDF.Next.Should().Be(halfEdgeFH);
             halfEdgeDF.Twin.Should().Be(halfEdgeFD);
-            halfEdgeDF.Previous.Should().Be(halfEdgeED);
+            halfEdgeDF.Previous.Should().Be(halfEdgeHD);
             halfEdgeDF.OriginalSegment.Should().Be(segmentJ);
 
-            halfEdgeHF.Next.Should().Be(halfEdgeFD);
+            halfEdgeHF.Next.Should().Be(halfEdgeFG);
             halfEdgeHF.Twin.Should().Be(halfEdgeFH);
-            halfEdgeHF.Previous.Should().Be(halfEdgeDH);
+            halfEdgeHF.Previous.Should().Be(halfEdgeGH);
             halfEdgeHF.OriginalSegment.Should().Be(segmentK);
 
-            halfEdgeFH.Next.Should().Be(halfEdgeHG);
+            halfEdgeFH.Next.Should().Be(halfEdgeHD);
             halfEdgeFH.Twin.Should().Be(halfEdgeHF);
-            halfEdgeFH.Previous.Should().Be(halfEdgeGF);
+            halfEdgeFH.Previous.Should().Be(halfEdgeDF);
             halfEdgeFH.OriginalSegment.Should().Be(segmentK);
 
             halfEdgeGA.Next.Should().Be(halfEdgeAB);
             halfEdgeGA.Twin.Should().Be(halfEdgeAG);
-            halfEdgeGA.Previous.Should().Be(halfEdgeFG);
+            halfEdgeGA.Previous.Should().Be(halfEdgeHG);
             halfEdgeGA.OriginalSegment.Should().Be(segmentL);
 
-            halfEdgeAG.Next.Should().Be(halfEdgeGH);
+            halfEdgeAG.Next.Should().Be(halfEdgeGF);
             halfEdgeAG.Twin.Should().Be(halfEdgeGA);
             halfEdgeAG.Previous.Should().Be(halfEdgeBA);
             halfEdgeAG.OriginalSegment.Should().Be(segmentL);
@@ -815,35 +815,35 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
             var face5 = result.Faces[4];
             var face6 = result.Faces[5];
 
-            face1.HalfEdges.Should().HaveCount(7);
+            face1.HalfEdges.Should().HaveCount(5);
             face1.HalfEdges.All(he => he.Face == face1).Should().BeTrue();
             face1.HalfEdges.Should()
-                 .Contain(new[] {halfEdgeAB, halfEdgeBC, halfEdgeCD, halfEdgeDE, halfEdgeEF, halfEdgeFG, halfEdgeGA});
+                 .Contain(new[] {halfEdgeAB, halfEdgeBC, halfEdgeCH, halfEdgeHG, halfEdgeGA});
 
-            face2.HalfEdges.Should().HaveCount(5);
+            face2.HalfEdges.Should().HaveCount(7);
             face2.HalfEdges.All(he => he.Face == face2).Should().BeTrue();
             face2.HalfEdges.Should()
-                 .Contain(new[] {halfEdgeAG, halfEdgeGH, halfEdgeHC, halfEdgeCB, halfEdgeBA});
+                 .Contain(new[] {halfEdgeBA, halfEdgeCB, halfEdgeDC, halfEdgeED, halfEdgeFE, halfEdgeGF, halfEdgeAG});
 
             face3.HalfEdges.Should().HaveCount(3);
             face3.HalfEdges.All(he => he.Face == face3).Should().BeTrue();
             face3.HalfEdges.Should()
-                 .Contain(new[] {halfEdgeCH, halfEdgeHD, halfEdgeDC});
+                 .Contain(new[] {halfEdgeHC, halfEdgeCD, halfEdgeDH});
 
             face4.HalfEdges.Should().HaveCount(3);
             face4.HalfEdges.All(he => he.Face == face4).Should().BeTrue();
             face4.HalfEdges.Should()
-                 .Contain(new[] {halfEdgeFE, halfEdgeED, halfEdgeDF});
+                 .Contain(new[] {halfEdgeFD, halfEdgeDE, halfEdgeEF});
 
             face6.HalfEdges.Should().HaveCount(3);
             face6.HalfEdges.All(he => he.Face == face6).Should().BeTrue();
             face6.HalfEdges.Should()
-                 .Contain(new[] {halfEdgeFD, halfEdgeDH, halfEdgeHF});
+                 .Contain(new[] {halfEdgeHD, halfEdgeDF, halfEdgeFH});
 
             face5.HalfEdges.Should().HaveCount(3);
             face5.HalfEdges.All(he => he.Face == face5).Should().BeTrue();
             face5.HalfEdges.Should()
-                 .Contain(new[] {halfEdgeHG, halfEdgeGF, halfEdgeFH});
+                 .Contain(new[] {halfEdgeGH, halfEdgeHF, halfEdgeFG});
         }
 
         [Fact]

--- a/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
+++ b/tests/Ethereality.DoublyConnectedEdgeList.Tests/DcelE2eTests.cs
@@ -317,6 +317,34 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
         }
 
         [Fact]
+        public void Given_a_shape_with_right_triangle_and_added_edge_Should_return_valid_dcel()
+        {
+            // Arrange
+            var a = new TestPoint(-1, 2);
+            var b = new TestPoint(4, 3);
+            var c = new TestPoint(5, -2);
+            var d = new TestPoint(4, 4);
+
+            var segmentA = new TestSegment(a, b);
+            var segmentB = new TestSegment(b, c);
+            var segmentC = new TestSegment(c, a);
+            var segmentD = new TestSegment(b, d);
+
+            var segments = new[] { segmentA, segmentB, segmentC, segmentD };
+
+            var dcelFactory = new DcelFactory<TestSegment, TestPoint>(new TestSegmentComparer());
+
+            // Act
+            var result = dcelFactory.FromShape(segments);
+
+            // check the next of half edge AB; it should be BD
+            var halfEdgeAB = result.FindHalfEdge(a, b);
+            var halfEdgeBD = result.FindHalfEdge(b, d);
+            halfEdgeAB.Next.Should().Be(halfEdgeBD);
+        }
+
+
+        [Fact]
         public void Given_a_shape_with_hole_Should_return_valid_dcel()
         {
             // Arrange

--- a/tests/Ethereality.DoublyConnectedEdgeList.Tests/TestSegmentComparer.cs
+++ b/tests/Ethereality.DoublyConnectedEdgeList.Tests/TestSegmentComparer.cs
@@ -7,18 +7,41 @@ namespace Ethereality.DoublyConnectedEdgeList.Tests
     {
         public int Compare(TestSegment x, TestSegment y)
         {
-            var angleX = CalculateAngle(x);
-            var angleY = CalculateAngle(y);
+            var reverseX = false;
+            var reverseY = false;
+
+            if (x.PointB.Equals(y.PointB))
+            {
+                reverseX = true;
+                reverseY = true;
+            }
+
+            if (x.PointA.Equals(y.PointB))
+            {
+                reverseX = false;
+                reverseY = true;
+            }
+
+            if (x.PointB.Equals(y.PointA))
+            {
+                reverseX = true;
+                reverseY = false;
+            }
+
+            var angleX = CalculateAngle(x, reverseX);
+            var angleY = CalculateAngle(y, reverseY);
 
             return Math.Sign(angleY - angleX);
         }
 
-        private static double CalculateAngle(TestSegment segment)
+        private static double CalculateAngle(TestSegment segment, bool reverseDirection)
         {
             var distanceX = segment.PointB.X - segment.PointA.X;
             var distanceY = segment.PointB.Y - segment.PointA.Y;
 
-            return Math.Atan2(distanceY, distanceX);
+            return reverseDirection
+                ? Math.Atan2(-distanceY, -distanceX)
+                : Math.Atan2(distanceY, distanceX);
         }
     }
 }

--- a/tests/shapes/complex_shape.svg
+++ b/tests/shapes/complex_shape.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="145.21707mm"
    height="135.61812mm"
    viewBox="0 0 145.21707 135.61812"
    version="1.1"
    id="svg8"
-   inkscape:version="0.92.4 (5da689c313, 2019-01-14)"
-   sodipodi:docname="complex_shape.svg">
+   inkscape:version="1.1 (c68e22c387, 2021-05-23)"
+   sodipodi:docname="complex_shape.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs2" />
   <sodipodi:namedview
@@ -26,8 +26,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="1.4"
-     inkscape:cx="163.54567"
-     inkscape:cy="215.82407"
+     inkscape:cx="163.21429"
+     inkscape:cy="215.71429"
      inkscape:document-units="mm"
      inkscape:current-layer="layer1"
      showgrid="true"
@@ -35,14 +35,15 @@
      inkscape:guide-bbox="true"
      inkscape:snap-grids="false"
      inkscape:window-width="1920"
-     inkscape:window-height="1017"
-     inkscape:window-x="3832"
-     inkscape:window-y="-8"
+     inkscape:window-height="1018"
+     inkscape:window-x="-6"
+     inkscape:window-y="-6"
      inkscape:window-maximized="1"
      fit-margin-top="3"
      fit-margin-left="3"
      fit-margin-right="3"
-     fit-margin-bottom="3" />
+     fit-margin-bottom="3"
+     inkscape:pagecheckerboard="0" />
   <metadata
      id="metadata5">
     <rdf:RDF>
@@ -131,7 +132,7 @@
        r="0.6687603" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="34.222301"
        y="137.48595"
        id="text4669"><tspan
@@ -139,10 +140,10 @@
          id="tspan4667"
          x="34.222301"
          y="137.48595"
-         style="fill:#0000ff;stroke-width:0.26458332">A(-60; 0)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">A(-60; 0)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="157.20917"
        y="136.82387"
        id="text4669-8"><tspan
@@ -150,10 +151,10 @@
          id="tspan4667-6"
          x="157.20917"
          y="136.82387"
-         style="fill:#0000ff;stroke-width:0.26458332">B(60; 0)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">B(60; 0)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="145.18027"
        y="93.545601"
        id="text4669-8-8"><tspan
@@ -161,10 +162,10 @@
          id="tspan4667-6-2"
          x="145.18027"
          y="93.545601"
-         style="fill:#0000ff;stroke-width:0.26458332">C(40; 40)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">C(40; 40)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="46.189785"
        y="93.923576"
        id="text4669-8-8-0"><tspan
@@ -172,10 +173,10 @@
          id="tspan4667-6-2-5"
          x="46.189785"
          y="93.923576"
-         style="fill:#0000ff;stroke-width:0.26458332">G(-40; 40)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">G(-40; 40)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="66.033531"
        y="53.669109"
        id="text4669-8-8-0-8"><tspan
@@ -183,10 +184,10 @@
          id="tspan4667-6-2-5-1"
          x="66.033531"
          y="53.669109"
-         style="fill:#0000ff;stroke-width:0.26458332">F(-20; 80)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">F(-20; 80)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="124.61982"
        y="53.480129"
        id="text4669-8-8-0-8-6"><tspan
@@ -194,10 +195,10 @@
          id="tspan4667-6-2-5-1-2"
          x="124.61982"
          y="53.480129"
-         style="fill:#0000ff;stroke-width:0.26458332">D(20; 80)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">D(20; 80)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="95.326675"
        y="97.325356"
        id="text4669-8-8-0-8-6-5"><tspan
@@ -205,10 +206,10 @@
          id="tspan4667-6-2-5-1-2-0"
          x="95.326675"
          y="97.325356"
-         style="fill:#0000ff;stroke-width:0.26458332">H(0; 40)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">H(0; 40)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="95.137703"
        y="10.579815"
        id="text4669-8-8-0-8-6-5-1"><tspan
@@ -216,10 +217,10 @@
          id="tspan4667-6-2-5-1-2-0-9"
          x="95.137703"
          y="10.579815"
-         style="fill:#0000ff;stroke-width:0.26458332">E(0; 120)</tspan></text>
+         style="fill:#0000ff;stroke-width:0.264583">E(0; 120)</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="154.5654"
        y="114.869"
        id="text4799"><tspan
@@ -227,10 +228,10 @@
          id="tspan4797"
          x="154.5654"
          y="114.869"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment B</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment B</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="96.908287"
        y="136.59975"
        id="text4799-8"><tspan
@@ -238,10 +239,10 @@
          id="tspan4797-2"
          x="96.908287"
          y="136.59975"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment A</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment A</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="134.36307"
        y="73.85569"
        id="text4799-6"><tspan
@@ -249,10 +250,10 @@
          id="tspan4797-5"
          x="134.36307"
          y="73.85569"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment C</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment C</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="115.44566"
        y="33.979198"
        id="text4799-6-2"><tspan
@@ -260,10 +261,10 @@
          id="tspan4797-5-7"
          x="115.44566"
          y="33.979198"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment D</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment D</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="75.494736"
        y="34.735157"
        id="text4799-6-2-3"><tspan
@@ -271,10 +272,10 @@
          id="tspan4797-5-7-7"
          x="75.494736"
          y="34.735157"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment E</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment E</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="54.707932"
        y="73.85569"
        id="text4799-6-2-3-4"><tspan
@@ -282,10 +283,10 @@
          id="tspan4797-5-7-7-6"
          x="54.707932"
          y="73.85569"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment F</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment F</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="74.950325"
        y="96.912239"
        id="text4799-6-2-3-4-8"><tspan
@@ -293,10 +294,10 @@
          id="tspan4797-5-7-7-6-7"
          x="74.950325"
          y="96.912239"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment G</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment G</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="116.51619"
        y="97.479195"
        id="text4799-6-2-3-4-8-1"><tspan
@@ -304,10 +305,10 @@
          id="tspan4797-5-7-7-6-7-6"
          x="116.51619"
          y="97.479195"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment I</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment I</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="106.99387"
        y="73.85569"
        id="text4799-6-2-3-4-8-1-7"><tspan
@@ -315,10 +316,10 @@
          id="tspan4797-5-7-7-6-7-6-0"
          x="106.99387"
          y="73.85569"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment H</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment H</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="83.937302"
        y="73.85569"
        id="text4799-6-2-3-4-8-1-7-7"><tspan
@@ -326,10 +327,10 @@
          id="tspan4797-5-7-7-6-7-6-0-0"
          x="83.937302"
          y="73.85569"
-         style="fill:#4d4d4d;stroke-width:0.26458332">Segment K</tspan></text>
+         style="fill:#4d4d4d;stroke-width:0.264583">Segment K</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#666666;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="95.465569"
        y="50.610157"
        id="text4799-6-2-3-4-8-1-7-7-2"><tspan
@@ -337,10 +338,10 @@
          id="tspan4797-5-7-7-6-7-6-0-0-1"
          x="95.465569"
          y="50.610157"
-         style="fill:#666666;stroke-width:0.26458332">Segment J</tspan></text>
+         style="fill:#666666;stroke-width:0.264583">Segment J</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="100.17439"
        y="38.121475"
        id="text5001"><tspan
@@ -348,12 +349,12 @@
          id="tspan4999"
          x="100.17439"
          y="38.121475"
-         style="font-size:4.23333311px;fill:#ff0000;stroke-width:0.26458332">F<tspan
-   style="font-size:64.99999762%;baseline-shift:sub"
+         style="font-size:4.23333px;fill:#ff0000;stroke-width:0.264583">F<tspan
+   style="font-size:65%;baseline-shift:sub"
    id="tspan5170">4</tspan></tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="99.993446"
        y="66.637833"
        id="text5001-5"><tspan
@@ -361,12 +362,12 @@
          id="tspan4999-0"
          x="99.993446"
          y="66.637833"
-         style="font-size:4.23333311px;fill:#ff0000;stroke-width:0.26458332">F<tspan
-   style="font-size:64.99999762%;baseline-shift:sub"
+         style="font-size:4.23333px;fill:#ff0000;stroke-width:0.264583">F<tspan
+   style="font-size:65%;baseline-shift:sub"
    id="tspan5174">6</tspan></tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="80.172546"
        y="81.567902"
        id="text5001-5-3"
@@ -376,12 +377,12 @@
          id="tspan4999-0-1"
          x="80.172546"
          y="81.567902"
-         style="font-size:4.23333311px;fill:#ff0000;stroke-width:0.26458332">F<tspan
-   style="font-size:64.99999762%;baseline-shift:sub"
+         style="font-size:4.23333px;fill:#ff0000;stroke-width:0.264583">F<tspan
+   style="font-size:65%;baseline-shift:sub"
    id="tspan5176">5</tspan></tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="120.43306"
        y="81.567902"
        id="text5001-5-3-0"
@@ -391,12 +392,12 @@
          id="tspan4999-0-1-1"
          x="120.43306"
          y="81.567902"
-         style="font-size:4.23333311px;fill:#ff0000;stroke-width:0.26458332">F<tspan
-   style="font-size:64.99999762%;baseline-shift:sub"
+         style="font-size:4.23333px;fill:#ff0000;stroke-width:0.264583">F<tspan
+   style="font-size:65%;baseline-shift:sub"
    id="tspan5172">3</tspan></tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="100.76418"
        y="116.36253"
        id="text5001-5-3-0-3"
@@ -406,12 +407,12 @@
          id="tspan4999-0-1-1-9"
          x="100.76418"
          y="116.36253"
-         style="font-size:4.23333311px;fill:#ff0000;stroke-width:0.26458332">F<tspan
-   style="font-size:64.99999762%;baseline-shift:sub"
+         style="font-size:4.23333px;fill:#ff0000;stroke-width:0.264583">F<tspan
+   style="font-size:65%;baseline-shift:sub"
    id="tspan5178">2</tspan></tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;font-size:2.82222223px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.26458332"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#ff0000;fill-opacity:1;stroke:none;stroke-width:0.264583"
        x="166.77812"
        y="73.462234"
        id="text5001-5-3-0-3-4"
@@ -421,8 +422,8 @@
          id="tspan4999-0-1-1-9-8"
          x="166.77812"
          y="73.462234"
-         style="font-size:4.23333311px;fill:#ff0000;stroke-width:0.26458332">F<tspan
-   style="font-size:64.99999762%;baseline-shift:sub"
+         style="font-size:4.23333px;fill:#ff0000;stroke-width:0.264583">F<tspan
+   style="font-size:65%;baseline-shift:sub"
    id="tspan5180">1</tspan></tspan></text>
     <ellipse
        style="opacity:1;fill:none;fill-opacity:1;stroke:#f90b10;stroke-width:0.40000001;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
@@ -466,5 +467,16 @@
        cy="115.24693"
        rx="4.3467264"
        ry="4.1577382" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-weight:normal;font-size:2.82222px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.264583"
+       x="34.731205"
+       y="114.869"
+       id="text249"><tspan
+         sodipodi:role="line"
+         x="34.731205"
+         y="114.869"
+         style="fill:#4d4d4d;stroke-width:0.264583"
+         id="tspan725">Segment L</tspan></text>
   </g>
 </svg>


### PR DESCRIPTION
The edge comparer implemented for the unit testing purpose fails to check which extremities of the two edges it compares are coincident. In particular, given a comparer `comparer` and two edges `edge1` and `edge2`,
```csharp
comparer.Compare(edge1, edge2)
```
and
```
comparer.Compare(edge1.Reverse(), edge2.Reverse())
```
or any combination should return the same result.

The unit tests must be adapted, since the ordering of the edges is modified. Using the figure 'complex_shape.svg', it is now trivial (but tedious...) to determine consistently the previous and next half edge of a given half edge by following the boundary of the associated face, keeping the face on the left side of the half edges.